### PR TITLE
refactor: fetch claim data from API

### DIFF
--- a/src/components/admin/claims-table.tsx
+++ b/src/components/admin/claims-table.tsx
@@ -15,45 +15,30 @@ import { CheckCircle, Download, XCircle } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { callApi } from "@/lib/api-client";
 
-const mockClaims = [
-  {
-    id: "CLM789123",
-    userName: "Alex Johnson",
-    userId: "user001",
-    flightNumber: "VN248",
-    flightDate: "2024-07-20",
-    submissionDate: "2024-07-21",
-    status: "pending",
-    attachmentUrl: "#",
-    miles: 1500,
-  },
-  {
-    id: "CLM456789",
-    userName: "Maria Garcia",
-    userId: "user002",
-    flightNumber: "VN773",
-    flightDate: "2024-07-18",
-    submissionDate: "2024-07-19",
-    status: "pending",
-    attachmentUrl: "#",
-    miles: 2800,
-  },
-  {
-    id: "CLM123456",
-    userName: "Sam Chen",
-    userId: "user003",
-    flightNumber: "QH1021",
-    flightDate: "2024-07-15",
-    submissionDate: "2024-07-16",
-    status: "pending",
-    attachmentUrl: "#",
-    miles: 850,
-  },
-];
+interface AdminClaim {
+  id: string;
+  userName: string;
+  userId: string;
+  flightNumber: string;
+  flightDate: string;
+  submissionDate: string;
+  status: string;
+  attachmentUrl: string;
+  miles: number;
+}
 
 export function ClaimsTable() {
-  const [claims, setClaims] = React.useState(mockClaims);
+  const [claims, setClaims] = React.useState<AdminClaim[]>([]);
+  const [error, setError] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(true);
   const { toast } = useToast();
+
+  React.useEffect(() => {
+    callApi<AdminClaim[]>({ method: "GET", path: "/api/claims", params: { status: "pending" } })
+      .then((data) => setClaims(data))
+      .catch((err: any) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
 
   const handleReview = async (
     claimId: string,
@@ -96,7 +81,19 @@ export function ClaimsTable() {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {claims.length > 0 ? (
+          {loading ? (
+            <TableRow>
+              <TableCell colSpan={6} className="text-center">
+                Loading...
+              </TableCell>
+            </TableRow>
+          ) : error ? (
+            <TableRow>
+              <TableCell colSpan={6} className="text-center text-destructive">
+                {error}
+              </TableCell>
+            </TableRow>
+          ) : claims.length > 0 ? (
             claims.map((claim) => (
               <TableRow key={claim.id}>
                 <TableCell className="font-medium">{claim.id}</TableCell>

--- a/src/components/dashboard/claims-history.tsx
+++ b/src/components/dashboard/claims-history.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as React from "react";
 import {
   Card,
   CardContent,
@@ -17,46 +18,28 @@ import {
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import { callApi } from "@/lib/api-client";
 
-const mockClaims = [
-  {
-    id: "CLM987654",
-    flightNumber: "VN248",
-    flightDate: "2024-05-15",
-    status: "Approved",
-    miles: 1500,
-  },
-  {
-    id: "CLM876543",
-    flightNumber: "VJ161",
-    flightDate: "2024-04-22",
-    status: "Approved",
-    miles: 950,
-  },
-  {
-    id: "CLM765432",
-    flightNumber: "QH1021",
-    flightDate: "2024-03-30",
-    status: "Rejected",
-    miles: 0,
-  },
-  {
-    id: "CLM654321",
-    flightNumber: "VN773",
-    flightDate: "2024-02-11",
-    status: "Approved",
-    miles: 2800,
-  },
-  {
-    id: "CLM543210",
-    flightNumber: "VN216",
-    flightDate: "2024-01-05",
-    status: "Pending",
-    miles: 0,
-  },
-];
+interface Claim {
+  id: string;
+  flightNumber: string;
+  flightDate: string;
+  status: string;
+  miles: number;
+}
 
 export function ClaimsHistory() {
+  const [claims, setClaims] = React.useState<Claim[]>([]);
+  const [error, setError] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    callApi<Claim[]>({ method: "GET", path: "/api/claims" })
+      .then((data) => setClaims(data))
+      .catch((err: any) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
   return (
     <Card>
       <CardHeader>
@@ -67,48 +50,72 @@ export function ClaimsHistory() {
       </CardHeader>
       <CardContent>
         <div className="w-full overflow-x-auto">
-            <Table>
+          <Table>
             <TableHeader>
-                <TableRow>
+              <TableRow>
                 <TableHead>Claim ID</TableHead>
                 <TableHead>Flight</TableHead>
                 <TableHead>Date</TableHead>
                 <TableHead>Status</TableHead>
                 <TableHead className="text-right">Miles</TableHead>
-                </TableRow>
+              </TableRow>
             </TableHeader>
             <TableBody>
-                {mockClaims.map((claim) => (
-                <TableRow key={claim.id}>
+              {loading ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-center">
+                    Loading...
+                  </TableCell>
+                </TableRow>
+              ) : error ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-center text-destructive">
+                    {error}
+                  </TableCell>
+                </TableRow>
+              ) : claims.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-center">
+                    No recent claims.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                claims.map((claim) => (
+                  <TableRow key={claim.id}>
                     <TableCell className="font-medium">{claim.id}</TableCell>
                     <TableCell>{claim.flightNumber}</TableCell>
                     <TableCell>{claim.flightDate}</TableCell>
                     <TableCell>
-                    <Badge
+                      <Badge
                         variant={
-                        claim.status === "Approved"
+                          claim.status === "Approved"
                             ? "default"
                             : claim.status === "Pending"
                             ? "secondary"
                             : "destructive"
                         }
-                        className={cn(claim.status === 'Approved' && 'bg-green-600 text-white')}
-                    >
+                        className={cn(
+                          claim.status === "Approved" && "bg-green-600 text-white"
+                        )}
+                      >
                         {claim.status}
-                    </Badge>
+                      </Badge>
                     </TableCell>
                     <TableCell
-                    className={cn(
+                      className={cn(
                         "text-right font-semibold",
                         claim.status === "Approved" && "text-green-600"
-                    )}
+                      )}
                     >
-                    {claim.status === "Approved" ? `+${claim.miles.toLocaleString()}` : "-"}
+                      {claim.status === "Approved"
+                        ? `+${claim.miles.toLocaleString()}`
+                        : "-"}
                     </TableCell>
-                </TableRow>
-                ))}
+                  </TableRow>
+                ))
+              )}
             </TableBody>
-            </Table>
+          </Table>
         </div>
       </CardContent>
     </Card>

--- a/src/components/dashboard/stats-cards.tsx
+++ b/src/components/dashboard/stats-cards.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as React from "react";
 import {
   Card,
   CardContent,
@@ -8,36 +9,75 @@ import {
 } from "@/components/ui/card";
 import { Award, Gauge, PlaneTakeoff, ShieldCheck } from "lucide-react";
 import { useTranslation } from "@/lib/i18n";
+import { callApi } from "@/lib/api-client";
+
+interface DashboardStats {
+  totalMiles: number;
+  tierStatus: string;
+  tierProgress: string;
+  pendingClaims: number;
+}
 
 export function StatsCards() {
   const { t } = useTranslation();
+  const [stats, setStats] = React.useState<DashboardStats | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(true);
 
-  const stats = [
+  React.useEffect(() => {
+    callApi<DashboardStats>({ method: "GET", path: "/api/stats" })
+      .then((data) => setStats(data))
+      .catch((err: any) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("dashboard.stats.total_miles")}</CardTitle>
+          </CardHeader>
+          <CardContent>Loading...</CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (error) {
+    return <div className="text-destructive">{error}</div>;
+  }
+
+  if (!stats) {
+    return <div>{t("dashboard.stats.total_miles")}: 0</div>;
+  }
+
+  const statItems = [
     {
       title: t("dashboard.stats.total_miles"),
-      value: "124,530",
+      value: stats.totalMiles.toLocaleString(),
       Icon: PlaneTakeoff,
     },
     {
       title: t("dashboard.stats.tier_status"),
-      value: "Gold",
+      value: stats.tierStatus,
       Icon: Award,
     },
     {
       title: t("dashboard.stats.tier_progress"),
-      value: "4,470 miles to Platinum",
+      value: stats.tierProgress,
       Icon: Gauge,
     },
     {
       title: t("dashboard.stats.pending_claims"),
-      value: "1",
+      value: stats.pendingClaims.toString(),
       Icon: ShieldCheck,
     },
   ];
 
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-      {stats.map((stat) => (
+      {statItems.map((stat) => (
         <Card key={stat.title}>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">{stat.title}</CardTitle>


### PR DESCRIPTION
## Summary
- load dashboard stats via API instead of hardcoded values
- fetch member claim history from API with proper loading and error states
- replace admin claims table mock data with API-driven list

## Testing
- `npm run lint` (fails: prompts for ESLint configuration)
- `npm run typecheck` (fails: Cannot find module 'firebase/auth' or corresponding types)


------
https://chatgpt.com/codex/tasks/task_e_68961d853108832bbb9f8f3b20c4667f