### PR TITLE
Wrap admin layout with sidebar provider

### DIFF
--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -1,17 +1,35 @@
 "use client";
 
-import { SidebarProvider, Sidebar, SidebarInset } from "@/components/ui/sidebar";
-import AdminSidebar  from "@/components/layout/admin/sidebar";
+import {
+  SidebarProvider,
+  Sidebar,
+  SidebarInset,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
+import AdminSidebar from "@/components/layout/admin/sidebar";
 import AdminHeader from "@/components/layout/admin/header";
 import { useIsMobile } from "@/hooks/use-mobile";
 
-export default function AdminLayout({ children }: { children: React.ReactNode }) {
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const isMobile = useIsMobile();
+
   return (
-    <div className="min-h-screen flex bg-gray-50">
-      <AdminSidebar />
-      <div className="flex-1 flex flex-col">
-        <main className="mx-auto w-full max-w-screen-xl px-3 sm:px-4 lg:px-6">{children}</main>
-      </div>
-    </div>
+    <SidebarProvider defaultOpen={!isMobile}>
+      <Sidebar>
+        <AdminSidebar />
+      </Sidebar>
+      <SidebarInset>
+        <AdminHeader>
+          <SidebarTrigger className="mr-2" />
+        </AdminHeader>
+        <main className="mx-auto w-full max-w-screen-xl px-3 sm:px-4 lg:px-6">
+          {children}
+        </main>
+      </SidebarInset>
+    </SidebarProvider>
   );
 }

--- a/src/components/layout/admin/header.tsx
+++ b/src/components/layout/admin/header.tsx
@@ -6,12 +6,14 @@ import { LotusIcon } from "@/components/icons"; // hoặc Logo nhỏ
 import { LanguageSwitcher } from "@/components/language-switcher";
 import { Button } from "@/components/ui/button";
 import { LogOut, User, Cog } from "lucide-react";
+import { ReactNode } from "react";
 
 type Props = {
   title?: string;
+  children?: ReactNode;
 };
 
-export default function AdminHeader({ title }: Props) {
+export default function AdminHeader({ title, children }: Props) {
   const { t } = useTranslation();
 
   return (
@@ -19,6 +21,7 @@ export default function AdminHeader({ title }: Props) {
       <div className="max-w-full h-full px-4 lg:px-6 flex items-center justify-between">
         {/* Left: brand (small) + title */}
         <div className="flex items-center gap-3">
+          {children}
           <Link href="/admin/dashboard" className="flex items-center gap-2">
             <LotusIcon className="h-6 w-6 text-teal-600" />
           </Link>


### PR DESCRIPTION
## Summary
- integrate sidebar provider and trigger into admin layout
- allow AdminHeader to render child elements, such as the sidebar trigger

## Testing
- `npm run typecheck`
- `npm run check-routes`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a892e27d9c832bab8e8cd086d349ba