### PR TITLE
Add sidebar trigger to admin header

### DIFF
--- a/src/components/layout/admin/header.tsx
+++ b/src/components/layout/admin/header.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useTranslation } from "@/lib/i18n";
 import { LotusIcon } from "@/components/icons"; // hoặc Logo nhỏ
 import { LanguageSwitcher } from "@/components/language-switcher";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 import { Button } from "@/components/ui/button";
 import { LogOut, User, Cog } from "lucide-react";
 
@@ -30,6 +31,7 @@ export default function AdminHeader({ title }: Props) {
 
         {/* Right: language + quick actions */}
         <div className="flex items-center gap-2">
+          <SidebarTrigger className="lg:hidden" />
           <LanguageSwitcher />
           <Button asChild variant="ghost" size="sm" className="text-gray-700">
             <Link href="/admin/profile"><User className="h-4 w-4 mr-2" />{t("admin.header.profile")}</Link>


### PR DESCRIPTION
## Summary
- show sidebar toggle button on small screens in admin header
- import sidebar trigger component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a892e364e0832baf6b06dea24e1196