### PR TITLE
Add viewport meta tag to root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import "./globals.css";
 export const metadata: Metadata = {
   title: "Lotus Loyalty Hub",
   description: "Vietnam Airlines Loyalty Program",
+  viewport: "width=device-width, initial-scale=1",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- include viewport setting in layout metadata to ensure proper scaling on mobile devices

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint configuration)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a892e22708832b96494d5c575e5d6d